### PR TITLE
Filecache: Fix LS2 roles

### DIFF
--- a/files/sysbus/com.palm.filecache.role.json.in
+++ b/files/sysbus/com.palm.filecache.role.json.in
@@ -5,6 +5,7 @@
     "permissions": [
         {
             "service":"com.palm.filecache",
+            "inbound":["com.palm.configurator"],
             "outbound":[]
         }
     ]


### PR DESCRIPTION
Solves: May 01 12:59:15 qemux86-64 ls-hubd[186]: [] [pmlog] ls-hubd LSHUB_NO_INB_PERMS {"DEST_APP_ID":"com.palm.filecache","SRC_APP_ID":"com.palm.configurator","EXE":"/usr/sbin/configurator","PID":475} Permissions does not allow inbound connections from "com.palm.configurator" to "com.palm.filecache" (cmdline: /usr/sbin/configurator -c {"log":{"appender":{"type":"syslog"},"levels":{"configurator":"notice"}}} service)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>