### PR TITLE
filecache: Add outbound permissions for com.palm.configurator

### DIFF
--- a/files/sysbus/com.palm.filecache.role.json.in
+++ b/files/sysbus/com.palm.filecache.role.json.in
@@ -6,7 +6,7 @@
         {
             "service":"com.palm.filecache",
             "inbound":["com.palm.configurator"],
-            "outbound":[]
+            "outbound":["com.palm.configurator"]
         }
     ]
 }


### PR DESCRIPTION
Fixes:

Jun 15 14:57:50 qemux86-64 ls-hubd[267]: [] [pmlog] ls-hubd LSHUB_NO_OUT_PERMS {"DEST_APP_ID":"com.palm.configurator","SRC_APP_ID":"com.palm.filecache","EXE":"/usr/sbin/filecache","PID":440} "com.palm.filecache" does not have sufficient outbound permissions to communicate with "com.palm.configurator" (cmdline: /usr/sbin/filecache -c {"log":{"appender":{"type":"syslog"},"levels":{"default":"warning"}}})

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>