### PR TITLE
Allow "" and com.palm.imap/smtp/pop to have inbound/outbound access to filecache

### DIFF
--- a/files/sysbus/com.palm.filecache.role.json.in
+++ b/files/sysbus/com.palm.filecache.role.json.in
@@ -5,8 +5,8 @@
     "permissions": [
         {
             "service":"com.palm.filecache",
-            "inbound":["com.palm.configurator"],
-            "outbound":["com.palm.configurator"]
+            "inbound":["", "com.palm.configurator", "com.palm.imap", "com.palm.smtp", "com.palm.pop"],
+            "outbound":["", "com.palm.configurator", "com.palm.imap", "com.palm.smtp", "com.palm.pop"]
         }
     ]
 }


### PR DESCRIPTION
Solves various inbound permission errors for email.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>