### PR TITLE
filecache: Add access for com.palm.service.accounts/contacts/contacts…

### DIFF
--- a/files/sysbus/com.palm.filecache.role.json.in
+++ b/files/sysbus/com.palm.filecache.role.json.in
@@ -5,8 +5,8 @@
     "permissions": [
         {
             "service":"com.palm.filecache",
-            "inbound":["", "com.palm.configurator", "com.palm.imap", "com.palm.smtp", "com.palm.pop"],
-            "outbound":["", "com.palm.configurator", "com.palm.imap", "com.palm.smtp", "com.palm.pop"]
+            "inbound":["", "com.palm.configurator", "com.palm.imap", "com.palm.smtp", "com.palm.pop", "com.palm.service.accounts", "com.palm.service.contacts", "com.palm.service.contacts.linker", "com.palm.service.calendar.reminders"],
+            "outbound":["", "com.palm.configurator", "com.palm.imap", "com.palm.smtp", "com.palm.pop", "com.palm.service.accounts", "com.palm.service.contacts", "com.palm.service.contacts.linker", "com.palm.service.calendar.reminders"]
         }
     ]
 }


### PR DESCRIPTION
….linker/calendar.reminders

So that the sync if contacts & calendar events can use filecache to write their images etc.

Solves:
{"typeName":"contactphoto","size":8192,"fileName":"Google C+DAVHerrieTest.jpeg","subscribe":true}: Not permitted to send to com.palm.filecache.     at Object.create (/usr/palm/frameworks/foundations/version/1.0/node_module.js:1:1365)     at /usr/palm/frameworks/foundations/version/1.0/node_module.js:1:35436     at Future.<anonymous> (/usr/palm/frameworks/foundations/version/1.0/node_module.js:1:11037)     at Timeout.d [as _onTimeout] (/usr/palm/frameworks/foundations/version/1.0/node_module.js:1:16017)     at ontimeout (timers.js:436:11)     at tryOnTimeout (timers.js:300:5)     at listOnTimeout (timers.js:263:5)     at Timer.processTimers (timers.js:223:10)

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>