### PR TITLE
filecache: Fix ACG configuration

### DIFF
--- a/files/sysbus/com.palm.filecache.perm.json
+++ b/files/sysbus/com.palm.filecache.perm.json
@@ -1,0 +1,3 @@
+{
+    "com.palm.filecache": ["signals.register"]
+}

--- a/files/sysbus/com.palm.filecache.role.json.in
+++ b/files/sysbus/com.palm.filecache.role.json.in
@@ -5,8 +5,8 @@
     "permissions": [
         {
             "service":"com.palm.filecache",
-            "inbound":["", "com.palm.configurator", "com.palm.imap", "com.palm.smtp", "com.palm.pop", "com.palm.service.accounts", "com.palm.service.contacts", "com.palm.service.contacts.linker", "com.palm.service.calendar.reminders"],
-            "outbound":["", "com.palm.configurator", "com.palm.imap", "com.palm.smtp", "com.palm.pop", "com.palm.service.accounts", "com.palm.service.contacts", "com.palm.service.contacts.linker", "com.palm.service.calendar.reminders"]
+            "inbound":["", "com.palm.*", "com.webos.*", "org.webosports.*"],
+            "outbound":["", "com.palm.*", "com.webos.*", "org.webosports.*"]
         }
     ]
 }


### PR DESCRIPTION
Let's simply allow wildcard com.palm.*, com.webos.* and com.webosports.* to have access to filecache.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>